### PR TITLE
Use 4096-bit DH prime, equivalent to AES-128

### DIFF
--- a/bin/openvpn.sh
+++ b/bin/openvpn.sh
@@ -5,7 +5,7 @@ apt-get update -q
 apt-get install -qy openvpn curl
 
 cd /etc/openvpn
-[ -f dh.pem ] || openssl dhparam -out dh.pem 4096
+[ -f dh.pem ] || openssl dhparam -out dh.pem 2048
 
 [ -f ca-key.pem ] || openssl genrsa -out ca-key.pem 2048
 chmod 600 ca-key.pem


### PR DESCRIPTION
We're using DH over a finite field modulo a prime, not ECDH. To have the same strength as a 150-bit symmetric cipher key, against the best attack techniques 2004 had to offer, we'd need about a 4575-bit DH modulus.[1] AES-128 is about as hard to break as a 3200-bit DH modulus given the best techniques of 2001.[2]

[1] https://tools.ietf.org/html/rfc3766 (see table in section 5)
[2] http://tools.ietf.org/html/rfc3526
