### PR TITLE
updated shebang to bash instead of sh

### DIFF
--- a/bin/openvpn.sh
+++ b/bin/openvpn.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # Script to set up OpenVPN for routing all traffic.
 # Modified from Tinfoil Security's openvpn_autoconfig:


### PR DESCRIPTION
fixes [[: not found because [[ is bash built-in and not available in sh
