### PR TITLE
Force cURL to use IPv4. Avoid IPv6 server name

### DIFF
--- a/bin/openvpn.sh
+++ b/bin/openvpn.sh
@@ -49,7 +49,7 @@ iptables -t nat -A POSTROUTING -s 10.8.0.0/24 -o eth0 -j MASQUERADE
 
 # Write configuration files for client and server
 
-SERVER_IP=$(curl -s canhazip.com || echo "<insert server IP here>")
+SERVER_IP=$(curl -s4 canhazip.com || echo "<insert server IP here>")
 
 >tcp443.conf cat <<EOF
 server      10.8.0.0 255.255.255.0


### PR DESCRIPTION
If the server is configured to make outgoing requests with IPv6 whenever possible, then the `curl` command to `canhazip.com` will return the server's IPv6 URL.

This is undesirable, because this script only configures OpenVPN for IPv4. A more long-term fix would be to enable OpenVPN over IPv6, in the face of IPv4 address exhaustion.